### PR TITLE
feat: add lyrics cleaning + TF‑IDF preprocessing notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -487,6 +487,9 @@ secrets.sh
 # models
 notebooks/models/*.joblib
 
+# vectorizers
+data/processed/*.joblib
+
 # project shell/python helpers - not Windows venv Scripts/
 !scripts/
 !scripts/**

--- a/notebooks/04_clean_lyrics.ipynb
+++ b/notebooks/04_clean_lyrics.ipynb
@@ -20,7 +20,6 @@
         "- `data/raw/spotify_millsongdata.csv`\n",
         "\n",
         "### Outputs\n",
-        "- `data/processed/lyrics_cleaned.parquet`\n",
         "- `data/processed/lyrics_cleaned.csv`"
       ]
     },

--- a/notebooks/04_clean_lyrics.ipynb
+++ b/notebooks/04_clean_lyrics.ipynb
@@ -1,0 +1,702 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Spotify Lyrics Cleaning\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "27621b51",
+      "metadata": {},
+      "source": [
+        "### Goal\n",
+        "Turn `data/raw/spotify_millsongdata.csv` into a **clean, deduplicated, normalized** lyrics table that’s easy to align to Spotify tracks later.\n",
+        "\n",
+        "### Input\n",
+        "- `data/raw/spotify_millsongdata.csv`\n",
+        "\n",
+        "### Outputs\n",
+        "- `data/processed/lyrics_cleaned.parquet`\n",
+        "- `data/processed/lyrics_cleaned.csv`"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "21856f44",
+      "metadata": {},
+      "source": [
+        "### 1. Setup & Data Loading"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "0ea4f4c3",
+      "metadata": {},
+      "source": [
+        "#### 1.1 Path Configuration"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "id": "5f970845",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os \n",
+        "\n",
+        "IS_KAGGLE = os.path.exists(\"/kaggle/input\")\n",
+        "\n",
+        "if IS_KAGGLE:\n",
+        "    DATA_PATH = \"/kaggle/input/spotify-million-song-dataset/spotify_millsongdata.csv\"\n",
+        "    OUTPUT_PATH = \"/kaggle/working/\"\n",
+        "else:\n",
+        "    DATA_PATH = \"../data/raw/spotify_millsongdata.csv\"\n",
+        "    OUTPUT_PATH = \"../data/cleaned/\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "26411e74",
+      "metadata": {},
+      "source": [
+        "#### 1.2 Import required packages"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "653428e1",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import re\n",
+        "import unicodedata\n",
+        "from pathlib import Path\n",
+        "import numpy as np\n",
+        "import pandas as pd"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "((57650, 4), ['artist', 'song', 'link', 'text'])"
+            ]
+          },
+          "execution_count": 3,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df = pd.read_csv(DATA_PATH)\n",
+        "df.shape, df.columns.tolist()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>artist</th>\n",
+              "      <th>song</th>\n",
+              "      <th>link</th>\n",
+              "      <th>text</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>ABBA</td>\n",
+              "      <td>Ahe's My Kind Of Girl</td>\n",
+              "      <td>/a/abba/ahes+my+kind+of+girl_20598417.html</td>\n",
+              "      <td>Look at her face, it's a wonderful face&nbsp;&nbsp;\\r\\nA...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>ABBA</td>\n",
+              "      <td>Andante, Andante</td>\n",
+              "      <td>/a/abba/andante+andante_20002708.html</td>\n",
+              "      <td>Take it easy with me, please&nbsp;&nbsp;\\r\\nTouch me gen...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>ABBA</td>\n",
+              "      <td>As Good As New</td>\n",
+              "      <td>/a/abba/as+good+as+new_20003033.html</td>\n",
+              "      <td>I'll never know why I had to go&nbsp;&nbsp;\\r\\nWhy I had...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "  artist                   song                                        link  \\\n",
+              "0   ABBA  Ahe's My Kind Of Girl  /a/abba/ahes+my+kind+of+girl_20598417.html   \n",
+              "1   ABBA       Andante, Andante       /a/abba/andante+andante_20002708.html   \n",
+              "2   ABBA         As Good As New        /a/abba/as+good+as+new_20003033.html   \n",
+              "\n",
+              "                                                text  \n",
+              "0  Look at her face, it's a wonderful face  \\r\\nA...  \n",
+              "1  Take it easy with me, please  \\r\\nTouch me gen...  \n",
+              "2  I'll never know why I had to go  \\r\\nWhy I had...  "
+            ]
+          },
+          "execution_count": 4,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df.head(3)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "74209237",
+      "metadata": {},
+      "source": [
+        "### 2. Data Cleaning"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "artist    0.0\n",
+            "song      0.0\n",
+            "link      0.0\n",
+            "text      0.0\n",
+            "dtype: float64\n",
+            "dup rows: 0\n",
+            "dup artist+song: 2\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Basic QA\n",
+        "print(df.isna().mean().sort_values(ascending=False).head(10))\n",
+        "print(\"dup rows:\", df.duplicated().sum())\n",
+        "print(\"dup artist+song:\", df.duplicated([\"artist\", \"song\"]).sum())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "65248edf",
+      "metadata": {},
+      "source": [
+        "Since there is no missing values, no duplicated rows and only 1 duplicate artist + song, there is not much cleaning to be done."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "46ef7506",
+      "metadata": {},
+      "source": [
+        "### 3. Normalization"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "57a5a7f1",
+      "metadata": {},
+      "source": [
+        "#### 3.1 Define Regular Expressions"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "6d2daedc",
+      "metadata": {},
+      "source": [
+        "1. `_RE_FEAT`: matches “feature credits” like feat. ..., ft ..., or featuring ... (case-insensitive), including everything after it to the end of the string.\n",
+        "\n",
+        "    Example: `\"Drake feat. Rihanna\"` → it matches `\" feat. Rihanna\"` so you can remove it.\n",
+        "\n",
+        "2. `_RE_PARENS`: matches any text inside parentheses (...) or brackets [...] (non-greedy), including surrounding whitespace.\n",
+        "\n",
+        "    Example: `\"Song Title (Remastered 2011)\"` → it matches `\"(Remastered 2011)\"` so you can strip it.\n",
+        "\n",
+        "3. `_RE_NON_ALNUM`: matches any character that is not a lowercase letter a-z, digit 0-9, or whitespace `\\s`.\n",
+        "\n",
+        "    Example: `\"Beyoncé!\"` (after lowercasing/diacritics handling) → it matches punctuation like `!` so you can replace it with spaces and normalize tokens."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "id": "9ab483a6",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "_RE_FEAT = re.compile(r\"\\s*\\b(?:feat\\.?|ft\\.?|featuring)\\b.*$\", flags=re.IGNORECASE)\n",
+        "_RE_PARENS = re.compile(r\"\\s*[\\(\\[].*?[\\)\\]]\\s*\")\n",
+        "_RE_NON_ALNUM = re.compile(r\"[^a-z0-9\\s]+\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b0495f55",
+      "metadata": {},
+      "source": [
+        "#### 3.2 Remove accents/diacritics"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "de749c81",
+      "metadata": {},
+      "source": [
+        "It removes accents/diacritics from a string (e.g., turns “Beyoncé” into “Beyonce”), while keeping the base letters.  \n",
+        "\n",
+        "- `unicodedata.normalize(\"NFKD\", s)`: converts characters into a decomposed form where accented letters are split into:\n",
+        "    1. a base character + a combining accent mark\n",
+        "    \n",
+        "        Example: \"é\" → \"e\" + \"◌́\" (combining acute accent)\n",
+        "\n",
+        "- if not `unicodedata.combining(ch)`: filters out those combining accent marks.\n",
+        "\n",
+        "- `\"\".join(...)`: stitches the remaining base characters back into a normal string.\n",
+        "\n",
+        "&nbsp;  \n",
+        "**EXAMPLE:**  \n",
+        "&nbsp;  \n",
+        "Input: `\"Señorita\"` → Output: `\"Senorita\"`  \n",
+        "&nbsp;  \n",
+        "Input: `\"Björk\"` → Output: `\"Bjork\"`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "id": "15778ddc",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def _strip_accents(s: str) -> str:\n",
+        "    return \"\".join(\n",
+        "        ch for ch in unicodedata.normalize(\"NFKD\", s) if not unicodedata.combining(ch)\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e90536b9",
+      "metadata": {},
+      "source": [
+        "#### 3.3 Normalize Artists\n",
+        "\n",
+        "It converts an artist name into a standardized “join key” format so the same artist is more likely to match across datasets (Spotify vs lyrics).  \n",
+        "\n",
+        "- **Handle missing input**: if `s is None` or becomes empty after stripping → return `\"\"`.\n",
+        "\n",
+        "- **Lowercase + trim**: makes matching case-insensitive and removes leading/trailing spaces.\n",
+        "\n",
+        "- **Remove feature credits** (`_RE_FEAT.sub(\"\", s)`): strips parts like `feat. ..., ft ..., featuring ...` if present (common in Spotify-style strings).\n",
+        "\n",
+        "- **Remove accents** (`_strip_accents`): e.g., Beyoncé → Beyonce.\n",
+        "\n",
+        "- **Replace punctuation/symbols with spaces** (`_RE_NON_ALNUM.sub(\" \", s)`): keeps only a-z, 0-9, and whitespace.\n",
+        "\n",
+        "- **Collapse repeated whitespace**: turns multiple spaces into one, then trims again.  \n",
+        "\n",
+        "&nbsp;  \n",
+        "**EXAMPLE:**\n",
+        "&nbsp;  \n",
+        "1. \"Beyoncé feat. JAY-Z\" → \"beyonce\"  \n",
+        "2. \"AC/DC\" → \"ac dc\"  \n",
+        "3. \" Crosby, Stills & Nash \" → \"crosby stills nash\"  "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "id": "1ab33a25",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def norm_artist(s: str) -> str:\n",
+        "    if s is None:\n",
+        "        return \"\"\n",
+        "    s = str(s).strip().lower()\n",
+        "    if not s:\n",
+        "        return \"\"\n",
+        "    s = _RE_FEAT.sub(\"\", s)\n",
+        "    s = _strip_accents(s)\n",
+        "    s = _RE_NON_ALNUM.sub(\" \", s)\n",
+        "    s = re.sub(r\"\\s+\", \" \", s).strip()\n",
+        "    return s"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "300b4171",
+      "metadata": {},
+      "source": [
+        "#### 3.4 Normalize Titles\n",
+        "\n",
+        "It normalizes a song/track title into a consistent “join key” so titles match better between Spotify and the lyrics dataset, even when one side includes extra annotations.  \n",
+        "\n",
+        "- **Missing/empty guard**: if `s` is `None` or becomes empty → return `\"\"`.  \n",
+        "\n",
+        "- **Lowercase + trim**: reduces formatting differences.  \n",
+        "\n",
+        "- **Remove accents**: \"Señorita\" → \"senorita\".  \n",
+        "\n",
+        "- **Remove parenthetical/bracketed info**: `_RE_PARENS.sub(\" \", s)`\n",
+        "strips things like `(Remastered 2011)`, `[Live]`, `(feat. ...)`, etc.  \n",
+        "\n",
+        "- **Drop dash suffixes**: if `\" - \"` appears, keep only what’s before it.  \n",
+        "\n",
+        "    handles Spotify-like `\"Song Title - Remastered 2011\"`, `\"Track - Radio Edit\"`, etc.  \n",
+        "\n",
+        "- **Remove feature tails**: `_RE_FEAT.sub(\"\", s)` removes `\"feat...\"` text if present.  \n",
+        "\n",
+        "- **Standardize ampersand**: `\"&\"` → `\" and \"` so `\"Simon & Garfunkel\"` matches `\"Simon and Garfunkel\"`.  \n",
+        "\n",
+        "- **Remove punctuation/symbols and keep only letters/digits/spaces**: `_RE_NON_ALNUM.sub(\" \", s)`  \n",
+        "\n",
+        "- **Collapse whitespace** to a single space and trim.  \n",
+        "\n",
+        "&nbsp;  \n",
+        "**EXAMPLE:**\n",
+        "&nbsp;\n",
+        "1. \"HUMBLE. (Remastered)\" → \"humble\"  \n",
+        "2. \"Lucky - Radio Edit\" → \"lucky\"  \n",
+        "3. \"Rock & Roll [Live]\" → \"rock and roll\"  "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "id": "bc3b0e7d",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def norm_title(s: str) -> str:\n",
+        "    if s is None:\n",
+        "        return \"\"\n",
+        "    s = str(s).strip().lower()\n",
+        "    if not s:\n",
+        "        return \"\"\n",
+        "    s = _strip_accents(s)\n",
+        "    s = _RE_PARENS.sub(\" \", s)\n",
+        "    if \" - \" in s:\n",
+        "        s = s.split(\" - \", 1)[0]\n",
+        "    s = _RE_FEAT.sub(\"\", s)\n",
+        "    s = s.replace(\"&\", \" and \")\n",
+        "    s = _RE_NON_ALNUM.sub(\" \", s)\n",
+        "    s = re.sub(r\"\\s+\", \" \", s).strip()\n",
+        "    return s"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a79c459d",
+      "metadata": {},
+      "source": [
+        "#### 3.5 Normalize Lyrics \n",
+        "\n",
+        "It normalizes the raw lyrics text into a clean, consistent string (mainly fixing line breaks and whitespace) so downstream vectorization/features are less noisy.\n",
+        " \n",
+        "- **Missing guard**: if `text` is `None`, return an empty string `\"\"`.   \n",
+        "\n",
+        "- **Ensure it’s a string**: `t = str(text)` (handles cases where the value isn’t already `str`).  \n",
+        "\n",
+        "- **Normalize line endings**:  \n",
+        "    \n",
+        "    Converts Windows-style `\\r\\n` and old Mac `\\r` into standard `\\n`.  \n",
+        "\n",
+        "- **Collapse repeated spaces/tabs**:\n",
+        "    \n",
+        "    `re.sub(r\"[ \\t]+\", \" \", t)` replaces runs of spaces and tabs with a single space.  \n",
+        "\n",
+        "- **Reduce excessive blank lines**:\n",
+        "    \n",
+        "    `re.sub(r\"\\n{3,}\", \"\\n\\n\", t)` turns 3+ consecutive newlines into just 2 (keeps paragraph breaks, removes huge gaps).  \n",
+        "\n",
+        "- **Trim edges**: `strip()` removes leading/trailing whitespace/newlines.  \n",
+        "\n",
+        "&nbsp;  \n",
+        "**EXAMPLE:**  \n",
+        "&nbsp;  \n",
+        "If the raw lyrics contain inconsistent `\\r\\n` and a lot of spacing, this function makes it consistent so the same lyric doesn’t look “different” just due to formatting.\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def clean_lyrics(text: str) -> str:\n",
+        "    if text is None:\n",
+        "        return \"\"\n",
+        "    t = str(text)\n",
+        "    t = t.replace(\"\\r\\n\", \"\\n\").replace(\"\\r\", \"\\n\")\n",
+        "    t = re.sub(r\"[ \\t]+\", \" \", t)\n",
+        "    t = re.sub(r\"\\n{3,}\", \"\\n\\n\", t)\n",
+        "    return t.strip()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "19f98c24",
+      "metadata": {},
+      "source": [
+        "### 4. Build Spotify Lyrics Cleaned"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "deb9d634",
+      "metadata": {},
+      "source": [
+        "This section builds a cleaned lyrics table from the raw Millsong dataframe, creates normalized join keys (artist_norm, title_norm), cleans the lyrics text, then deduplicates so you keep one best lyric per (artist_norm, title_norm) pair."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "clean = df[[\"artist\", \"song\", \"link\", \"text\"]].copy()\n",
+        "clean[\"artist_norm\"] = clean[\"artist\"].map(norm_artist)\n",
+        "clean[\"title_norm\"] = clean[\"song\"].map(norm_title)\n",
+        "clean[\"lyrics\"] = clean[\"text\"].map(clean_lyrics)\n",
+        "\n",
+        "clean[\"lyrics_char_len\"] = clean[\"lyrics\"].str.len().astype(\"int64\")\n",
+        "\n",
+        "# Keep longest lyrics per (artist_norm, title_norm)\n",
+        "clean = (\n",
+        "    clean.sort_values(\"lyrics_char_len\", ascending=False)\n",
+        "    .drop_duplicates([\"artist_norm\", \"title_norm\"], keep=\"first\")\n",
+        "    .reset_index(drop=True)\n",
+        ")   "
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "1e075e4a",
+      "metadata": {},
+      "source": [
+        "### 5. Check"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "id": "0eb6c849",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(57438, 8)"
+            ]
+          },
+          "execution_count": 13,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "clean.shape"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>artist</th>\n",
+              "      <th>song</th>\n",
+              "      <th>artist_norm</th>\n",
+              "      <th>title_norm</th>\n",
+              "      <th>lyrics_char_len</th>\n",
+              "      <th>lyrics</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>Z-Ro</td>\n",
+              "      <td>Plex</td>\n",
+              "      <td>z ro</td>\n",
+              "      <td>plex</td>\n",
+              "      <td>3925</td>\n",
+              "      <td>[Z-Ro] \\nThey say he was flipping out till, lo...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>Bob Dylan</td>\n",
+              "      <td>Bob Dylan's 115Th Dream</td>\n",
+              "      <td>bob dylan</td>\n",
+              "      <td>bob dylan s 115th dream</td>\n",
+              "      <td>3912</td>\n",
+              "      <td>I was riding on the Mayflower when I thought I...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>Eminem</td>\n",
+              "      <td>Hello</td>\n",
+              "      <td>eminem</td>\n",
+              "      <td>hello</td>\n",
+              "      <td>3909</td>\n",
+              "      <td>Hello (Hello) allow me to introduce myself (my...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>Snoop Dogg</td>\n",
+              "      <td>Doggy Dogg World</td>\n",
+              "      <td>snoop dogg</td>\n",
+              "      <td>doggy dogg world</td>\n",
+              "      <td>3903</td>\n",
+              "      <td>We'd like to welcome y'all to the fabulous Car...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>Tom Lehrer</td>\n",
+              "      <td>The Irish Ballad</td>\n",
+              "      <td>tom lehrer</td>\n",
+              "      <td>the irish ballad</td>\n",
+              "      <td>3902</td>\n",
+              "      <td>Now I'd like to turn to the folk song, which h...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "       artist                     song artist_norm               title_norm  \\\n",
+              "0        Z-Ro                     Plex        z ro                     plex   \n",
+              "1   Bob Dylan  Bob Dylan's 115Th Dream   bob dylan  bob dylan s 115th dream   \n",
+              "2      Eminem                    Hello      eminem                    hello   \n",
+              "3  Snoop Dogg         Doggy Dogg World  snoop dogg         doggy dogg world   \n",
+              "4  Tom Lehrer         The Irish Ballad  tom lehrer         the irish ballad   \n",
+              "\n",
+              "   lyrics_char_len                                             lyrics  \n",
+              "0             3925  [Z-Ro] \\nThey say he was flipping out till, lo...  \n",
+              "1             3912  I was riding on the Mayflower when I thought I...  \n",
+              "2             3909  Hello (Hello) allow me to introduce myself (my...  \n",
+              "3             3903  We'd like to welcome y'all to the fabulous Car...  \n",
+              "4             3902  Now I'd like to turn to the folk song, which h...  "
+            ]
+          },
+          "execution_count": 15,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "clean[[\"artist\", \"song\", \"artist_norm\", \"title_norm\", \"lyrics_char_len\", \"lyrics\"]].head(5)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "ee81e8b1",
+      "metadata": {},
+      "source": [
+        "### 6. Output"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Cleaned lyrics dataset saved to: ../data/cleaned/lyrics_cleaned.csv\n"
+          ]
+        }
+      ],
+      "source": [
+        "os.makedirs(OUTPUT_PATH, exist_ok=True)\n",
+        "clean.to_csv(OUTPUT_PATH + \"lyrics_cleaned.csv\", index=False)\n",
+        "print(f\"Cleaned lyrics dataset saved to: {OUTPUT_PATH + 'lyrics_cleaned.csv'}\")"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.14.4"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/notebooks/04_process_lyrics.ipynb
+++ b/notebooks/04_process_lyrics.ipynb
@@ -1,0 +1,365 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Spotify Lyrics Pre-processing\n",
+        "\n",
+        "### Goal\n",
+        "\n",
+        "Create reusable **text features** for lyrics (Model B) without persisting a combined Spotify+lyrics table.\n",
+        "\n",
+        "### Input\n",
+        "- `data/cleaned/lyrics_cleaned.csv`\n",
+        "\n",
+        "### Output\n",
+        "- `data/processed/lyrics_tfidf.joblib`\n",
+        "\n",
+        "Notes:\n",
+        "- TF-IDF is fit **only on the lyrics corpus** (no labels), so it’s safe."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "56caa760",
+      "metadata": {},
+      "source": [
+        "### 1. Setup & Data Loading"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "4bd0f8c5",
+      "metadata": {},
+      "source": [
+        "#### 1.1 Path Configuration"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "id": "e4bb1771",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "IS_KAGGLE: False\n",
+            "DATA_PATH: ../data/cleaned/lyrics_cleaned.csv\n",
+            "OUTPUT_PATH: ../data/processed/\n"
+          ]
+        }
+      ],
+      "source": [
+        "import os \n",
+        "\n",
+        "IS_KAGGLE = os.path.exists(\"/kaggle/input\")\n",
+        "\n",
+        "if IS_KAGGLE:\n",
+        "    DATA_PATH = \"/kaggle/working/lyrics_cleaned.csv\"\n",
+        "    OUTPUT_PATH = \"/kaggle/working/\"\n",
+        "else:\n",
+        "    DATA_PATH = \"../data/cleaned/lyrics_cleaned.csv\"\n",
+        "    OUTPUT_PATH = \"../data/processed/\"\n",
+        "\n",
+        "# Create output directory if it doesn't exist\n",
+        "os.makedirs(OUTPUT_PATH, exist_ok=True)\n",
+        "\n",
+        "# Print paths for confirmation\n",
+        "print(f\"IS_KAGGLE: {IS_KAGGLE}\")\n",
+        "print(f\"DATA_PATH: {DATA_PATH}\")\n",
+        "print(f\"OUTPUT_PATH: {OUTPUT_PATH}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b9a7696b",
+      "metadata": {},
+      "source": [
+        "#### 1.2 Import required packages"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "id": "212008e6",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "import joblib\n",
+        "import pandas as pd\n",
+        "from sklearn.feature_extraction.text import TfidfVectorizer"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "63e09891",
+      "metadata": {},
+      "source": [
+        "#### 1.3 Data Loading"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "id": "8614975a",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(True, PosixPath('../data/cleaned/lyrics_cleaned.csv'))"
+            ]
+          },
+          "execution_count": 5,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "Path(DATA_PATH).exists(), Path(DATA_PATH)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "id": "9815877f",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "lyr = pd.read_csv(DATA_PATH)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "id": "123e63fb",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "((57438, 8),\n",
+              " ['artist',\n",
+              "  'song',\n",
+              "  'link',\n",
+              "  'text',\n",
+              "  'artist_norm',\n",
+              "  'title_norm',\n",
+              "  'lyrics',\n",
+              "  'lyrics_char_len'])"
+            ]
+          },
+          "execution_count": 7,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "lyr.shape, lyr.columns.tolist()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "12fb40e1",
+      "metadata": {},
+      "source": [
+        "### 2. Lyrics Processing (Vectorize Lyrics)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "2863b1d7",
+      "metadata": {},
+      "source": [
+        "Fits a reusable TF‑IDF vectorizer on the lyrics corpus"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "4340293a",
+      "metadata": {},
+      "source": [
+        "#### 2.1 Build TfidVectorizer"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e177e216",
+      "metadata": {},
+      "source": [
+        "We build a TF‑IDF text representation of the lyrics dataset so that we can utilise the numeric features created from it."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "725488ef",
+      "metadata": {},
+      "source": [
+        "- **Creates a** `TfidfVectorizer` (`vec`) that will convert text → numeric features.  \n",
+        "\n",
+        "    1. `analyzer=\"char_wb\"`: uses character **n‑grams** within word boundaries (so it’s robust to spelling/punctuation differences and small variations like “remaster” vs “remastered”).  \n",
+        "    \n",
+        "    2. `ngram_range=(3, 5)`: extracts 3-, 4-, and 5-character chunks (e.g., `\"love\"` contributes `lov`, `ove`, etc.).  \n",
+        "    \n",
+        "    3. `min_df=5`: ignores n‑grams that appear in fewer than 5 documents (removes extremely rare noise).  \n",
+        " \n",
+        "    4. `max_df=0.5`: ignores n‑grams that appear in more than 50% of documents (removes overly common, low-signal patterns).  \n",
+        "&nbsp;  \n",
+        "- `fit_transform(...)`:\n",
+        "\n",
+        "    1. fits the vectorizer’s vocabulary + IDF weights on all lyrics, then\n",
+        "    \n",
+        "    2. transforms each lyric into a sparse TF‑IDF vector.\n",
+        "    \n",
+        "    3. `fillna(\"\")` ensures missing lyrics become empty strings instead of errors.  \n",
+        "&nbsp;  \n",
+        "- `X.shape` shows the resulting matrix size:\n",
+        "    \n",
+        "    1. rows = number of lyric documents\n",
+        "    \n",
+        "    2. columns = number of retained character n‑gram features"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "vec = TfidfVectorizer(\n",
+        "    analyzer=\"char_wb\",\n",
+        "    ngram_range=(3, 5),\n",
+        "    min_df=5,\n",
+        "    max_df=0.5,\n",
+        ")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "id": "7f6e70f6",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "X = vec.fit_transform(lyr[\"lyrics\"].fillna(\"\"))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "63efb58c",
+      "metadata": {},
+      "source": [
+        "### 3. Check"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "id": "1b6e4c93",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "(57438, 128303)"
+            ]
+          },
+          "execution_count": 11,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "X.shape"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "bb53e02d",
+      "metadata": {},
+      "source": [
+        "### 4. Output"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "923a6e20",
+      "metadata": {},
+      "source": [
+        "We dump vec (the fitted TfidfVectorizer) because it contains the feature definition needed to reproduce X consistently later:  \n",
+        "\n",
+        "**What vec stores**: the learned vocabulary (which n‑grams map to which column), the IDF weights, and all preprocessing settings (`analyzer`, `ngram_range`, `min_df`, `max_df`, etc.).  \n",
+        "\n",
+        "Without the same vec, the columns of X won’t match across runs/datasets.  \n",
+        "\n",
+        "**Why not dump X**:\n",
+        "\n",
+        "`X` is just the transformed matrix for this specific lyrics corpus. It’s not reusable for new data unless you also have the exact mapping.  \n",
+        "\n",
+        "In Model B, you’ll transform lyrics for the matched Spotify subset (and later any new lyrics) using the same `vec`:  \n",
+        "\n",
+        "  - `X_subset` = `vec.transform(subset_lyrics)`  \n",
+        "\n",
+        "`X` can be very large and is easy to recompute once vec is saved.  \n",
+        "\n",
+        "So: save `vec` to guarantee consistent features, and recompute `X` (or subsets of it) whenever needed."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "id": "80a66e58",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "os.makedirs(OUTPUT_PATH, exist_ok=True)\n",
+        "VEC_OUT = \"../data/processed/lyrics_tfidf.joblib\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "id": "3710cda8",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Saved vectorizer to: ../data/processed/lyrics_tfidf.joblib\n"
+          ]
+        }
+      ],
+      "source": [
+        "joblib.dump(vec, VEC_OUT)\n",
+        "print(f\"Saved vectorizer to: {VEC_OUT}\")"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.14.4"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
### **Summary**

- Adds `notebooks/04_clean_lyrics.ipynb` to clean and normalize `spotify_millsongdata` (dedupe + normalized artist/title keys + cleaned lyrics output).
- Adds `notebooks/04_process_lyrics.ipynb` to fit and persist a TF‑IDF vectorizer for downstream lyrics modeling.
- Updates `.gitignore` and fixes notebook output paths/locations for the new lyrics pipeline.

### **Why**

- Establishes a clear, reproducible lyrics preprocessing pipeline that can be used for a lyrics-only model (and later ensembling) without mixing it into the Spotify feature pipeline.

### **Test plan**

- Run `notebooks/04_clean_lyrics.ipynb` end-to-end and confirm it produces the cleaned lyrics dataset.
- Run `notebooks/04_process_lyrics.ipynb` and confirm it produces `lyrics_tfidf.joblib` and can` transform()` lyrics text without errors.

### **Notes**

These commits cover: f0ecc2c, 87ef71e, 58a421e, 275c654.

Made with Cursor.